### PR TITLE
Use the rak as executable for file_finder

### DIFF
--- a/lib/reruby/file_finder.rb
+++ b/lib/reruby/file_finder.rb
@@ -8,15 +8,18 @@ module Reruby
     end
 
     def paths_containing_word(word)
-      executable = find_executable('ag') || find_executable('ack')
-      command = Shellwords.shelljoin([executable, word, "-l", "-G", ruby_extensions_regex])
-      paths = paths_from_command(command)
+      paths = paths_from_command(command(word))
       filter_paths(paths)
     end
 
     private
 
     attr_reader :config
+
+    def command(word)
+      Shellwords.shelljoin([executable, word, "-l", "-g",
+                            ruby_extensions_regex])
+    end
 
     def paths_from_command(command)
       `#{command}`.split("\n")
@@ -42,17 +45,9 @@ module Reruby
       /#{path_regexes.join("|")}/
     end
 
-    def find_executable(cmd)
-      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
-      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-        exts.each do |ext|
-          exe = File.join(path, "#{cmd}#{ext}")
-          return exe if File.executable?(exe) && !File.directory?(exe)
-        end
-      end
-      return nil
+    def executable
+      "rak"
     end
-
 
   end
 end

--- a/reruby.gemspec
+++ b/reruby.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser"
   spec.add_dependency "activesupport"
   spec.add_dependency "thor"
+  spec.add_dependency "rak"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/reruby/file_finder_example/another_find_finder_test_file.rb
+++ b/spec/reruby/file_finder_example/another_find_finder_test_file.rb
@@ -1,0 +1,2 @@
+class FileFinderTest
+end

--- a/spec/reruby/file_finder_example/file_finder_test_file.rb
+++ b/spec/reruby/file_finder_example/file_finder_test_file.rb
@@ -1,0 +1,2 @@
+class FileFinderTest
+end

--- a/spec/reruby/file_finder_example/vendor/vendor_file_finder_test.rb
+++ b/spec/reruby/file_finder_example/vendor/vendor_file_finder_test.rb
@@ -1,0 +1,2 @@
+class FileFinderTest
+end

--- a/spec/reruby/file_finder_spec.rb
+++ b/spec/reruby/file_finder_spec.rb
@@ -8,13 +8,13 @@ describe Reruby::FileFinder do
       config = Reruby::Config.new(fallback_config: Reruby::Config.default)
       finder = Reruby::FileFinder.new(config: config)
 
-      expected_paths = ["spec/reruby/file_finder_spec.rb",
-                        "spec/reruby/file_finder_example/another_find_finder_test_file.rb",
+      expected_paths = ["spec/reruby/file_finder_example/another_find_finder_test_file.rb",
+                        "spec/reruby/file_finder_example/file_finder_test_file.rb",
                         "spec/reruby/file_finder_example/vendor/vendor_file_finder_test.rb",
-                        "spec/reruby/file_finder_example/file_finder_test_file.rb"]
+                        "spec/reruby/file_finder_spec.rb"]
 
       actual_paths = finder.paths_containing_word("FileFinderTest")
-      expect(actual_paths).to eq(expected_paths)
+      expect(actual_paths.sort).to eq(expected_paths)
     end
 
     it "excludes files as given in the the config" do
@@ -28,12 +28,12 @@ describe Reruby::FileFinder do
                                   options: config_options)
       finder = Reruby::FileFinder.new(config: config)
 
-      expected_paths = ["spec/reruby/file_finder_spec.rb",
-                        "spec/reruby/file_finder_example/another_find_finder_test_file.rb",
-                        "spec/reruby/file_finder_example/file_finder_test_file.rb"]
+      expected_paths = ["spec/reruby/file_finder_example/another_find_finder_test_file.rb",
+                        "spec/reruby/file_finder_example/file_finder_test_file.rb",
+                        "spec/reruby/file_finder_spec.rb"]
 
       actual_paths = finder.paths_containing_word("FileFinderTest")
-      expect(actual_paths).to eq(expected_paths)
+      expect(actual_paths.sort).to eq(expected_paths)
     end
   end
 end

--- a/spec/reruby/file_finder_spec.rb
+++ b/spec/reruby/file_finder_spec.rb
@@ -2,31 +2,38 @@ require 'spec_helper'
 
 describe Reruby::FileFinder do
 
-  it "excludes files as given in the the config" do
-    config_options = {
-      "paths" => {
-        "exclude" => ["^vendor"]
+  describe "#paths_containing_word" do
+    it "lists the paths containing the word given" do
+
+      config = Reruby::Config.new(fallback_config: Reruby::Config.default)
+      finder = Reruby::FileFinder.new(config: config)
+
+      expected_paths = ["spec/reruby/file_finder_spec.rb",
+                        "spec/reruby/file_finder_example/another_find_finder_test_file.rb",
+                        "spec/reruby/file_finder_example/vendor/vendor_file_finder_test.rb",
+                        "spec/reruby/file_finder_example/file_finder_test_file.rb"]
+
+      actual_paths = finder.paths_containing_word("FileFinderTest")
+      expect(actual_paths).to eq(expected_paths)
+    end
+
+    it "excludes files as given in the the config" do
+      config_options = {
+        "paths" => {
+          "exclude" => ["vendor"]
+        }
       }
-    }
 
-    stubbed_paths = [
-      "app/vendor/hola",
-      "vendor/hola",
-      "lib/hola"
-    ]
+      config = Reruby::Config.new(fallback_config: Reruby::Config.default,
+                                  options: config_options)
+      finder = Reruby::FileFinder.new(config: config)
 
-    config = Reruby::Config.new(fallback_config: Reruby::Config.default,
-                                options: config_options)
-    finder = Reruby::FileFinder.new(config: config)
-    allow(finder).to receive(:paths_from_command) { stubbed_paths }
+      expected_paths = ["spec/reruby/file_finder_spec.rb",
+                        "spec/reruby/file_finder_example/another_find_finder_test_file.rb",
+                        "spec/reruby/file_finder_example/file_finder_test_file.rb"]
 
-    expected_paths = [
-      "app/vendor/hola",
-      "lib/hola"
-    ]
-    actual_paths = finder.paths_containing_word("")
-
-    expect(actual_paths).to eq(expected_paths)
+      actual_paths = finder.paths_containing_word("FileFinderTest")
+      expect(actual_paths).to eq(expected_paths)
+    end
   end
-
 end


### PR DESCRIPTION
Remove the "ag" and "ack" options for executables in the file_finder and use the "rak" instead.