### PR TITLE
Avoid rewriting unrelated requires using 'rename_const'

### DIFF
--- a/lib/reruby/rename_const/require_rewriter.rb
+++ b/lib/reruby/rename_const/require_rewriter.rb
@@ -25,7 +25,16 @@ module Reruby
 
     def requires_from?(required_str)
       require_expr = required_str.slice(1 .. -2)
-      require_expr.start_with?(from_namespace.as_require)
+
+      exact_require?(require_expr) || dangling_require?(require_expr)
+    end
+
+    def exact_require?(require_expr)
+      require_expr == from_namespace.as_require
+    end
+
+    def dangling_require?(require_expr)
+      require_expr.start_with?(from_namespace.as_require) && require_expr.include?("/")
     end
 
     def require_method?(method_name)

--- a/spec/reruby/rename_const/require_rewriter_spec.rb
+++ b/spec/reruby/rename_const/require_rewriter_spec.rb
@@ -66,4 +66,16 @@ describe Reruby::RenameConst::UsageRewriter do
 
     expect(actual_refactored).to eql(expected_refactored)
   end
+
+  it "doesn't change unrelated requires containing the original const" do
+    renamer = Reruby::RenameConst::RequireRewriter.new(from: "Log", to: "SuperLog")
+
+    code = <<-EOF
+      require 'logger'
+    EOF
+
+    actual_refactored = inline_refactor(code, renamer)
+
+    expect(actual_refactored).to eql(code)
+  end
 end


### PR DESCRIPTION
While playing a little bit with the tool, I was bitten due to `RequireRewriter`'s ability to handle dangling namespaces.

Not sure the slash presence is gonna be enough, it seems like it's doing the trick for now though.

