### PR TITLE
Improve require handling

### DIFF
--- a/lib/reruby/explode_namespace/children_namespace_files.rb
+++ b/lib/reruby/explode_namespace/children_namespace_files.rb
@@ -28,8 +28,7 @@ module Reruby
 
     def namespaces_to_extract
       defined_consts.found.select do |const, _|
-        nesting_level = const.nesting_level_in(namespace_to_explode)
-        nesting_level == 1
+        const.nested_one_level_in?(namespace_to_explode)
       end
     end
 

--- a/lib/reruby/explode_namespace/main_file_rewriter.rb
+++ b/lib/reruby/explode_namespace/main_file_rewriter.rb
@@ -24,17 +24,14 @@ module Reruby
       const_group = ParserConstGroup.from_node_tree(const_node)
 
       namespace_tracker.open_namespace(const_group.as_namespace) do
-        if nested_one_level?(namespace_tracker.namespace)
+        current_namespace = namespace_tracker.namespace
+
+        if current_namespace.nested_one_level_in?(namespace_to_explode)
           remove(node.loc.expression)
         else
           content_nodes.each { |n| process(n) }
         end
       end
-    end
-
-    def nested_one_level?(const)
-      nesting = const.nesting_level_in(namespace_to_explode)
-      nesting == 1
     end
 
   end

--- a/lib/reruby/namespace.rb
+++ b/lib/reruby/namespace.rb
@@ -14,11 +14,9 @@ module Reruby
         flat_namespace.join("::")
       end
 
-      def nesting_level_in(other_namespace)
-        other_namespace.flat_namespace.zip(flat_namespace).each do |mine, other|
-          return nil if mine != other
-        end
-        length - other_namespace.length
+      def nested_one_level_in?(other_namespace)
+        nesting_level = nesting_level_in(other_namespace)
+        nesting_level == 1
       end
 
       def relativize
@@ -69,6 +67,15 @@ module Reruby
         end
 
         possibles.reject {|w| w.length != size }
+      end
+
+      private
+
+      def nesting_level_in(other_namespace)
+        other_namespace.flat_namespace.zip(flat_namespace).each do |mine, other|
+          return nil if mine != other
+        end
+        length - other_namespace.length
       end
     end
 

--- a/lib/reruby/namespace.rb
+++ b/lib/reruby/namespace.rb
@@ -19,6 +19,10 @@ module Reruby
         nesting_level == 1
       end
 
+      def nested_in_or_same_as?(other_namespace)
+        nesting_level_in(other_namespace)
+      end
+
       def relativize
         Namespace.from_list(flat_namespace)
       end
@@ -225,6 +229,14 @@ module Reruby
       end
 
       Relative.new(absolutes)
+    end
+
+    def self.from_require_path(require_path)
+      parts = require_path.split("/").map do |path_part|
+        path_part.camelize
+      end
+
+      Absolute.new(parts)
     end
 
   end

--- a/lib/reruby/rename_const/require_rewriter.rb
+++ b/lib/reruby/rename_const/require_rewriter.rb
@@ -12,9 +12,10 @@ module Reruby
       return unless require_method?(method_name)
 
       required_expr = node.children.last.loc.expression
-      return unless requires_from?(required_expr.source)
+      require_path = required_expr.source
+      return unless requires_from?(require_path)
 
-      new_require = change_require(required_expr.source)
+      new_require = change_require(require_path)
 
       replace(required_expr, new_require)
     end
@@ -23,9 +24,11 @@ module Reruby
 
     attr_reader :from_namespace, :to_namespace
 
-    def requires_from?(required_str)
-      require_expr = required_str.slice(1 .. -2)
-      require_expr.start_with?(from_namespace.as_require)
+    def requires_from?(require_path_with_quotes)
+      require_path = require_path_with_quotes.slice(1 .. -2)
+      required_namespace = Namespace.from_require_path(require_path)
+
+      required_namespace.nested_in_or_same_as?(from_namespace)
     end
 
     def require_method?(method_name)

--- a/spec/reruby/explode_namespace/children_namespace_files_spec.rb
+++ b/spec/reruby/explode_namespace/children_namespace_files_spec.rb
@@ -18,7 +18,7 @@ describe Reruby::ExplodeNamespace::ChildrenNamespaceFiles do
     expected = "class A\nmodule C; end\nend"
 
     actual = explode("A", code)
-    puts actual
+
     expect(actual["a/c.rb"]).to eq(expected)
   end
 

--- a/spec/reruby/namespace_spec.rb
+++ b/spec/reruby/namespace_spec.rb
@@ -178,7 +178,7 @@ describe Reruby::Namespace do
     end
   end
 
-  describe ".from_require" do
+  describe ".from_require_path" do
     it "returns the expected namespace to be defined in a given require path" do
       require_path = "foo/bar/baz"
       expected_namespace = Reruby::Namespace.from_source("Foo::Bar::Baz")

--- a/spec/reruby/namespace_spec.rb
+++ b/spec/reruby/namespace_spec.rb
@@ -149,6 +149,46 @@ describe Reruby::Namespace do
     end
   end
 
+  describe "#nested_in_or_same_as?" do
+    it "returns truthy when nested exactly one level deep in given namespace " do
+      one_ns = namespace(%w(Z::A::B))
+      given_ns = namespace(%w(Z::A))
+
+      result = one_ns.nested_in_or_same_as?(given_ns)
+
+      expect(result).to be_truthy
+    end
+
+    it "returns falsey when not nested in given namespace" do
+      one_ns = namespace(%w(Z::A))
+      given_ns = namespace(%w(J::A))
+
+      nested_one_level = one_ns.nested_in_or_same_as?(given_ns)
+
+      expect(nested_one_level).to be_falsey
+    end
+
+    it "returns truthy when given namespace is the same" do
+      one_ns = namespace(%w(Z::A))
+      given_ns = namespace(%w(Z::A))
+
+      nested_one_level = one_ns.nested_in_or_same_as?(given_ns)
+
+      expect(nested_one_level).to be_truthy
+    end
+  end
+
+  describe ".from_require" do
+    it "returns the expected namespace to be defined in a given require path" do
+      require_path = "foo/bar/baz"
+      expected_namespace = Reruby::Namespace.from_source("Foo::Bar::Baz")
+
+      result = Reruby::Namespace.from_require_path(require_path)
+
+      expect(result).to eq(expected_namespace)
+    end
+  end
+
   describe "others" do
     it "can turn itself into a unix path" do
       one_ns = namespace(%w(Some::ClassName))

--- a/spec/reruby/namespace_spec.rb
+++ b/spec/reruby/namespace_spec.rb
@@ -120,24 +120,32 @@ describe Reruby::Namespace do
 
   end
 
-  describe "#nesting_level_in" do
-    it "returns nil when they aren't nested" do
-      one_ns = namespace(%w(Z::A))
-      other_ns = namespace(%w(J::A))
+  describe "#nested_one_level_in?" do
+    it "returns truthy when nested exactly one level deep in given namespace " do
+      one_ns = namespace(%w(Z::A::B))
+      given_ns = namespace(%w(Z::A))
 
-      nesting_level = one_ns.nesting_level_in(other_ns)
+      nested_one_level = one_ns.nested_one_level_in?(given_ns)
 
-      expect(nesting_level).to be_nil
+      expect(nested_one_level).to be_truthy
     end
 
-    it "returns the number of different consts" do
+    it "returns falsey when not nested in given namespace" do
       one_ns = namespace(%w(Z::A))
-      other_ns = namespace(%w(Z::A::B::C))
+      given_ns = namespace(%w(J::A))
 
-      nesting_level = other_ns.nesting_level_in(one_ns)
+      nested_one_level = one_ns.nested_one_level_in?(given_ns)
 
-      expect(nesting_level).to eq 2
+      expect(nested_one_level).to be_falsey
+    end
 
+    it "returns falsey when nested more than one level deep in given namespace " do
+      one_ns = namespace(%w(Z::A::B::C))
+      given_ns = namespace(%w(Z::A))
+
+      nested_one_level = one_ns.nested_one_level_in?(given_ns)
+
+      expect(nested_one_level).to be_falsey
     end
   end
 

--- a/spec/reruby/rename_const/require_rewriter_spec.rb
+++ b/spec/reruby/rename_const/require_rewriter_spec.rb
@@ -67,11 +67,23 @@ describe Reruby::RenameConst::UsageRewriter do
     expect(actual_refactored).to eql(expected_refactored)
   end
 
-  it "doesn't change unrelated requires containing the original const" do
+  it "doesn't change unrelated requires containing the original const name" do
     renamer = Reruby::RenameConst::RequireRewriter.new(from: "Log", to: "SuperLog")
 
     code = <<-EOF
       require 'logger'
+    EOF
+
+    actual_refactored = inline_refactor(code, renamer)
+
+    expect(actual_refactored).to eql(code)
+  end
+
+  it "doesn't change unrelated multi-level requires containing the original const name" do
+    renamer = Reruby::RenameConst::RequireRewriter.new(from: "Super::Log", to: "SuperLog")
+
+    code = <<-EOF
+      require 'super/logger'
     EOF
 
     actual_refactored = inline_refactor(code, renamer)

--- a/spec/reruby/rename_const/require_rewriter_spec.rb
+++ b/spec/reruby/rename_const/require_rewriter_spec.rb
@@ -66,4 +66,16 @@ describe Reruby::RenameConst::UsageRewriter do
 
     expect(actual_refactored).to eql(expected_refactored)
   end
+
+  it "doesn't change unrelated requires containing the original const" do
+    renamer = Reruby::RenameConst::RequireRewriter.new(from: "Log", to: "SuperLog")
+
+    code = <<-EOF
+      require 'logger'
+    EOF
+
+    actual_refactored = inline_refactor(code, renamer)
+
+    expect(actual_refactored).to eql(code)
+  end
 end


### PR DESCRIPTION
Pairing with @dgsuarez ;)

These changes move away from working with naked `String`s. The require expression is first transformed into an (`Absolute`) `Namespace`, allowing nesting calculations from there onwards. 

Fixes issue #19.