### PR TITLE
Autocommit option

### DIFF
--- a/exe/reruby
+++ b/exe/reruby
@@ -16,6 +16,7 @@ class RerubyCLI < Thor
   class_option :"ruby-extensions", type: "array"
   class_option :"config-file", type: "string"
   class_option :report, type: "string"
+  class_option :autocommit, type: "boolean"
 
   desc "Rename a const", "rename From::Some::Const to Other"
 

--- a/lib/reruby.rb
+++ b/lib/reruby.rb
@@ -51,6 +51,8 @@ require 'reruby/extract_method/extracted_method'
 require 'reruby/extract_method/change_for_invocation_rewriter'
 require 'reruby/extract_method/add_new_method_rewriter'
 
+require 'reruby/git_autocommit'
+
 module Reruby
   def self.logger
     Log.instance.logger

--- a/lib/reruby/config_parser.rb
+++ b/lib/reruby/config_parser.rb
@@ -68,12 +68,10 @@ module Reruby
         'keyword-arguments' => {
           'extract_method' => {
             'keyword_arguments' => cli_options['keyword-arguments']
-          },
-          'autocommit' => {
-            'extract_method' => {
-              'autocommit' => cli_options['autocommit']
-            }
           }
+        },
+        'autocommit' => {
+          'autocommit' => cli_options['autocommit']
         }
       }
     end

--- a/lib/reruby/config_parser.rb
+++ b/lib/reruby/config_parser.rb
@@ -68,10 +68,12 @@ module Reruby
         'keyword-arguments' => {
           'extract_method' => {
             'keyword_arguments' => cli_options['keyword-arguments']
+          },
+          'autocommit' => {
+            'extract_method' => {
+              'autocommit' => cli_options['autocommit']
+            }
           }
-        },
-        'autocommit' => {
-          'autocommit' => cli_options['autocommit']
         }
       }
     end

--- a/lib/reruby/config_parser.rb
+++ b/lib/reruby/config_parser.rb
@@ -69,6 +69,9 @@ module Reruby
           'extract_method' => {
             'keyword_arguments' => cli_options['keyword-arguments']
           }
+        },
+        'autocommit' => {
+          'autocommit' => cli_options['autocommit']
         }
       }
     end

--- a/lib/reruby/explode_namespace.rb
+++ b/lib/reruby/explode_namespace.rb
@@ -9,6 +9,7 @@ module Reruby
     end
 
     def perform
+      autocommit
       create_new_files
       remove_nested_namespaces
       add_new_requires
@@ -54,6 +55,10 @@ module Reruby
 
     def autofix
       RubocopAutofix.new(changed_files).clean if config.get("rubocop_autofix")
+    end
+
+    def autocommit
+      GitAutocommit.new.autocommit if config.get('autocommit')
     end
 
     def original_class_name

--- a/lib/reruby/extract_method.rb
+++ b/lib/reruby/extract_method.rb
@@ -67,6 +67,9 @@ module Reruby
       RubocopAutofix.new(changed_files).clean if config.get('rubocop_autofix')
     end
 
+    def autocommit
+      GitAutocommit.new.autocommit if config.get("autocommit")
+    end
   end
 
 end

--- a/lib/reruby/extract_method.rb
+++ b/lib/reruby/extract_method.rb
@@ -11,6 +11,8 @@ module Reruby
     end
 
     def perform
+      autocommit
+
       add_method
       change_invocation
 
@@ -68,7 +70,7 @@ module Reruby
     end
 
     def autocommit
-      GitAutocommit.new.autocommit if config.get("autocommit")
+      GitAutocommit.new.autocommit if config.get('autocommit')
     end
   end
 

--- a/lib/reruby/git_autocommit.rb
+++ b/lib/reruby/git_autocommit.rb
@@ -1,0 +1,25 @@
+require 'git'
+
+module Reruby
+  class GitAutocommit
+    AUTOCOMMIT_MSG = 'Reruby autocommit before refactoring'.freeze
+    ROOT_PATH = File.expand_path('../../', File.dirname(__FILE__))
+
+    def initialize
+      @client = Git.open(ROOT_PATH)
+    end
+
+    def autocommit
+      begin
+        @client.add(all: true)
+        @client.commit(AUTOCOMMIT_MSG)
+      rescue StandardError => e
+        raise(AutocommitError, e.message)
+      end
+      Reruby.logger.info "Autocommit succesfully"
+    end
+  end
+end
+
+class AutocommitError < StandardError
+end

--- a/lib/reruby/instances_to_readers.rb
+++ b/lib/reruby/instances_to_readers.rb
@@ -9,6 +9,8 @@ module Reruby
     end
 
     def perform
+      GitAutocommit.new.autocommit if config.get('autocommit')
+
       rewriter = Rewriter.new(namespace: namespace)
       path = ns_paths.main_file
 

--- a/lib/reruby/rename_const.rb
+++ b/lib/reruby/rename_const.rb
@@ -10,6 +10,7 @@ module Reruby
     end
 
     def perform
+      autocommit
       candidates_for_usage = finder.paths_containing_word(from_namespace.last_const)
       last_required_path_part = from_namespace.as_require.split("/").last
       candidates_for_require = finder.paths_containing_word(last_required_path_part)
@@ -65,6 +66,10 @@ module Reruby
 
     def finder
       FileFinder.new(config: config)
+    end
+
+    def autocommit
+      GitAutocommit.new.autocommit if config.get('autocommit')
     end
 
   end

--- a/reruby.gemspec
+++ b/reruby.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "git"
   spec.add_dependency "parser"
   spec.add_dependency "thor"
 

--- a/spec/reruby/git_autocommit_spec.rb
+++ b/spec/reruby/git_autocommit_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Reruby::GitAutocommit do
+
+  it "calls to add and commit when autocommit" do
+    expect_any_instance_of(Git::Base).to receive(:add).with(all: true).once
+    expect_any_instance_of(Git::Base).to receive(:commit).with('Reruby autocommit before refactoring').once
+    subject.autocommit
+  end
+
+  it "raises AutocommitError if there is an error in the autocommit" do
+    expect_any_instance_of(Git::Base).to receive(:add).with(all: true).and_raise("fake error")
+    expect { subject.autocommit }.to raise_error(AutocommitError)
+  end
+
+end


### PR DESCRIPTION
Maybe you find some incoherence in the way I added the autocommit in the differet refactor class (sometimes I added a method and sometimes I inlined the conditional in the perform). That's because I wanted to follow the style of the `.perform` in each class.

Another idea for implementing this is to add a kind of before_filter when executing the `.perfom`, but I'm not sure if you want to have the flag options in all the refactor.

Let me know your ideas about this, :)
